### PR TITLE
Fix typo in Chapther 6.2. pg. 42.

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2217,7 +2217,7 @@ might happen:
   more space to the leaking process.  I explain this mechanism
   in Section~\ref{paging}.
 
-\item There there might be a limit on the amount of space a single
+\item There might be a limit on the amount of space a single
   process can allocate; beyond that, {\tt malloc} returns NULL.
 
 \item Eventually, a process might fill its virtual address space (or


### PR DESCRIPTION
Consecutive two "there"s. Simple grammar error.