### PR TITLE
Fix typo

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -4117,7 +4117,7 @@ After removing an item, \verb"queue_pop" unlocks the mutex, signals
 that the queue is not full, and returns.
 
 In the next section I'll show you how my Cond code works, but first I
-want to answer two frequently-asked question:
+want to answer two frequently-asked questions:
 
 \begin{itemize}
 


### PR DESCRIPTION
This fixes a missing plural 's' in the text.