### PR TITLE
Static local variables are allocated in the global segment

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1269,7 +1269,7 @@ because they are allocated automatically when a function is called,
 and freed automatically when the function returns.
 
 In C there is another kind of local variable, called ``static'',
-which is allocated in the static segment.  It is initialized when
+which is allocated in the global segment.  It is initialized when
 the program starts and keeps its value from one function call to
 the next.
 


### PR DESCRIPTION
I noticed an inconsistency in naming the segment where static local variables are allocated in C. This change might be wrong, but it makes sense to me given that static local variables aren't immutable.

Section 3.4 indicates "The globals segment contains global variables and local variables that are declared static."

