### PR TITLE
Correction DRAM is 100 ns access time, not 10 ns

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2776,7 +2776,7 @@ costs for each of these technologies.
              &   time     &   size       &          \\ \hline
     Register &   0.5 ns   &   256 B      &   ?      \\ \hline
     Cache    &   1 ns     &   2 MiB      &   ?      \\ \hline
-    DRAM     &   10 ns    &   4 GiB      &   \$10 / GiB       \\ \hline
+    DRAM     &   100 ns   &   4 GiB      &   \$10 / GiB       \\ \hline
     SSD      &   10 \mus  &   100 GiB    &   \$1 / GiB      \\ \hline
     HDD      &   5 ms     &   500 GiB    &   \$0.25 / GiB     \\ \hline
     Tape     &   minutes  &   1--2 TiB   &   \$0.02 / GiB      \\ \hline


### PR DESCRIPTION
`The following table shows typical access times, sizes, and 
costs for each of these technologies.`

Table was not updated in the previous commit that included the original correction.