### PR TITLE
Change duplicate 'Creating threads' section header

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -3291,7 +3291,7 @@ in a directory named {\tt counter}.  For information on downloading
 this code, see Section~\ref{code}.
 
 
-\section{Creating threads}
+\section{Pthreads}
 
 The most popular threading standard used with C is POSIX Threads, or Pthreads for short.  The POSIX standard defines a thread model and an interface for creating and controlling threads.  Most versions of UNIX provide an implementation of Pthreads.
 


### PR DESCRIPTION
I'm not sure if it was intentional or not, but an alternate heading seemed appropriate for the first sections on Pthreads.