### PR TITLE
Fix typo in 3.5: static vs global segments

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1289,7 +1289,7 @@ local variable.  The initialization happens only once, when the program
 starts.
 
 If you add this function to {\tt aspace.c} you can confirm that
-{\tt counter} is allocated in the static segment along with global
+{\tt counter} is allocated in the global segment along with global
 variables, not in the stack.
 
 


### PR DESCRIPTION
Corrects line to use "global" instead of "static" segment.

At the [end of section 3.5](https://github.com/AllenDowney/ThinkOS/blob/0305128caf7835a999d23f8ab8de19508f064733/book/book.tex#L1292), the book states that a static local variable "is allocated in the static segment along with global variables".

However, the previous section states that "globals segment contains global variables and local variables that are declared static." The "static segment contains immutable values, like string literals". This is confirmed by adding the `static int` to the code example in section 3.4 and observing that the address is 128 bits (0x70) larger than `global`.